### PR TITLE
Refactor: Change type of 'items' to interface 'List' from implementat…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/FilterDialogFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/FilterDialogFragment.java
@@ -38,7 +38,7 @@ public class FilterDialogFragment extends DialogFragment {
         filterDialogFragment.show(fragmentManager, TAG);
     }
 
-    public static void showDialog(FragmentManager fragmentManager, ArrayList<FilterItem> items) {
+    public static void showDialog(FragmentManager fragmentManager, List<FilterItem> items) {
         Bundle bundle = new Bundle();
         bundle.putParcelableArrayList(KEY_FILTER_ITEMS, items);
 


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses the issue where the type of "items" was specified as the implementation 'ArrayList' rather than the more flexible interface 'List'.

**Link to the the issue**
#19
