### PR TITLE
Persist data locally on mobile device for default start date of Ski season

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -1,12 +1,17 @@
 package de.dennisguse.opentracks.settings;
-
+import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.NumberPicker;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import java.text.DateFormatSymbols;
+import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.ActivityType;
@@ -22,6 +27,14 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
             getActivity().runOnUiThread(this::updateUnits);
         }
     };
+    @Override
+    public boolean onPreferenceTreeClick(Preference preference) {
+        if (preference.getKey().equals(getString(R.string.ski_season_start_key))) {
+            showCustomDatePickerDialog(); // Call method to show the dialog
+            return true;
+        }
+        return super.onPreferenceTreeClick(preference);
+    }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -63,6 +76,37 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
 
         super.onDisplayPreferenceDialog(preference);
     }
+    private void showCustomDatePickerDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+        View dialogView = getLayoutInflater().inflate(R.layout.custom_date_picker_dialog, null);
+        builder.setView(dialogView);
+
+        NumberPicker monthPicker = dialogView.findViewById(R.id.monthPicker);
+        NumberPicker dayPicker = dialogView.findViewById(R.id.dayPicker);
+
+        // Customize month picker
+        String[] months = new DateFormatSymbols().getShortMonths();
+        monthPicker.setMinValue(0);
+        monthPicker.setMaxValue(months.length - 1);
+        monthPicker.setDisplayedValues(months);
+
+        // Customize day picker
+        dayPicker.setMinValue(1);
+        dayPicker.setMaxValue(31);
+
+        builder.setTitle("Select Date");
+        builder.setPositiveButton("OK", (dialog, which) -> {
+            int selectedMonth = monthPicker.getValue();
+            int selectedDay = dayPicker.getValue();
+
+            String selectedDate = String.format(Locale.getDefault(), "%02d-%02d", selectedDay, selectedMonth + 1);
+
+        });
+        builder.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss());
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
 
     private void updateUnits() {
         UnitSystem unitSystem = PreferencesUtils.getUnitSystem();
@@ -74,7 +118,7 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
             case IMPERIAL_FEET, IMPERIAL_METER ->
                     R.array.stats_rate_imperial_options;
             case NAUTICAL_IMPERIAL ->
-                R.array.stats_rate_nautical_options;
+                    R.array.stats_rate_nautical_options;
         };
 
         String[] entries = getResources().getStringArray(entriesId);

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -4,6 +4,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.NumberPicker;
+import android.widget.TextView;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
@@ -11,11 +12,14 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import java.text.DateFormatSymbols;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.ActivityType;
 import de.dennisguse.opentracks.fragments.ChooseActivityTypeDialogFragment;
+
 
 public class DefaultsSettingsFragment extends PreferenceFragmentCompat
         implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller {

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -94,6 +94,10 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
         dayPicker.setMinValue(1);
         dayPicker.setMaxValue(31);
 
+        //default date
+        monthPicker.setValue(8);
+        dayPicker.setValue(1);
+
         builder.setTitle("Select Date");
         builder.setPositiveButton("OK", (dialog, which) -> {
             int selectedMonth = monthPicker.getValue();

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -4,7 +4,6 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.NumberPicker;
-import android.widget.TextView;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
@@ -12,8 +11,6 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import java.text.DateFormatSymbols;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.R;

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -1,12 +1,10 @@
 package de.dennisguse.opentracks.settings;
-
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.util.Log;
 import android.view.View;
 import android.widget.NumberPicker;
+import android.widget.TextView;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
@@ -14,6 +12,8 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import java.text.DateFormatSymbols;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
@@ -130,24 +130,21 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat
 
     private void updateUnits() {
         UnitSystem unitSystem = PreferencesUtils.getUnitSystem();
+
         ListPreference statsRatePreferences = findPreference(getString(R.string.stats_rate_key));
 
-        // Check for null to avoid NullPointerException
-        if (statsRatePreferences != null) {
-            int entriesId = switch (unitSystem) {
-                case METRIC -> R.array.stats_rate_metric_options;
-                case IMPERIAL_FEET, IMPERIAL_METER -> R.array.stats_rate_imperial_options;
-                case NAUTICAL_IMPERIAL -> R.array.stats_rate_nautical_options;
-            };
+        int entriesId = switch (unitSystem) {
+            case METRIC -> R.array.stats_rate_metric_options;
+            case IMPERIAL_FEET, IMPERIAL_METER ->
+                    R.array.stats_rate_imperial_options;
+            case NAUTICAL_IMPERIAL ->
+                    R.array.stats_rate_nautical_options;
+        };
 
-            String[] entries = getResources().getStringArray(entriesId);
-            statsRatePreferences.setEntries(entries);
+        String[] entries = getResources().getStringArray(entriesId);
+        statsRatePreferences.setEntries(entries);
 
-            // Further actions could be added here if needed, e.g., updating other related
-            // preferences.
-        } else {
-            Log.w("DefaultsSettingsFragment", "Stats rate preference is not found.");
-        }
+        HackUtils.invalidatePreference(statsRatePreferences);
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -104,6 +104,10 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat
         dayPicker.setMinValue(1);
         dayPicker.setMaxValue(31);
 
+        //default date
+        monthPicker.setValue(8);
+        dayPicker.setValue(1);
+
         // Set picker values to saved date or default
         String[] dateParts = defaultStartDate.split("-");
         int defaultMonth = Integer.parseInt(dateParts[0]) - 1;

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -85,8 +85,7 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat
     }
 
     private void showCustomDatePickerDialog() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        String defaultStartDate = prefs.getString(getString(R.string.ski_season_start_key), "09-01");
+        String defaultStartDate = PreferencesUtils.getSkiSeasonStartDate();
 
         AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
         View dialogView = getLayoutInflater().inflate(R.layout.custom_date_picker_dialog, null);
@@ -117,9 +116,7 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat
             int selectedMonth = monthPicker.getValue();
             int selectedDay = dayPicker.getValue();
             String selectedDate = String.format(Locale.getDefault(), "%02d-%02d", selectedMonth + 1, selectedDay);
-            SharedPreferences.Editor editor = prefs.edit();
-            editor.putString(getString(R.string.ski_season_start_key), selectedDate);
-            editor.apply();
+            PreferencesUtils.setSkiSeasonStartDate(selectedDate);
         });
         builder.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss());
 

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -1,7 +1,10 @@
 package de.dennisguse.opentracks.settings;
+
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.View;
 import android.widget.NumberPicker;
 
@@ -17,16 +20,20 @@ import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.ActivityType;
 import de.dennisguse.opentracks.fragments.ChooseActivityTypeDialogFragment;
 
-public class DefaultsSettingsFragment extends PreferenceFragmentCompat implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller {
+public class DefaultsSettingsFragment extends PreferenceFragmentCompat
+        implements ChooseActivityTypeDialogFragment.ChooseActivityTypeCaller {
 
-    // Used to forward update from ChooseActivityTypeDialogFragment; TODO Could be replaced with LiveData.
+    // Used to forward update from ChooseActivityTypeDialogFragment; TODO Could be
+    // replaced with LiveData.y
     private ActivityTypePreference.ActivityPreferenceDialog activityPreferenceDialog;
 
-    private final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener = (sharedPreferences, key) -> {
+    private final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener = (
+            sharedPreferences, key) -> {
         if (PreferencesUtils.isKey(R.string.stats_units_key, key)) {
             getActivity().runOnUiThread(this::updateUnits);
         }
     };
+
     @Override
     public boolean onPreferenceTreeClick(Preference preference) {
         if (preference.getKey().equals(getString(R.string.ski_season_start_key))) {
@@ -76,7 +83,11 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
 
         super.onDisplayPreferenceDialog(preference);
     }
+
     private void showCustomDatePickerDialog() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        String defaultStartDate = prefs.getString(getString(R.string.ski_season_start_key), "09-01");
+
         AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
         View dialogView = getLayoutInflater().inflate(R.layout.custom_date_picker_dialog, null);
         builder.setView(dialogView);
@@ -84,7 +95,7 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
         NumberPicker monthPicker = dialogView.findViewById(R.id.monthPicker);
         NumberPicker dayPicker = dialogView.findViewById(R.id.dayPicker);
 
-        // Customize month picker
+        // Customize month picker with retrieved date or default
         String[] months = new DateFormatSymbols().getShortMonths();
         monthPicker.setMinValue(0);
         monthPicker.setMaxValue(months.length - 1);
@@ -94,17 +105,21 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
         dayPicker.setMinValue(1);
         dayPicker.setMaxValue(31);
 
-        //default date
-        monthPicker.setValue(8);
-        dayPicker.setValue(1);
+        // Set picker values to saved date or default
+        String[] dateParts = defaultStartDate.split("-");
+        int defaultMonth = Integer.parseInt(dateParts[0]) - 1;
+        int defaultDay = Integer.parseInt(dateParts[1]);
+        monthPicker.setValue(defaultMonth);
+        dayPicker.setValue(defaultDay);
 
         builder.setTitle("Select Date");
         builder.setPositiveButton("OK", (dialog, which) -> {
             int selectedMonth = monthPicker.getValue();
             int selectedDay = dayPicker.getValue();
-
-            String selectedDate = String.format(Locale.getDefault(), "%02d-%02d", selectedDay, selectedMonth + 1);
-
+            String selectedDate = String.format(Locale.getDefault(), "%02d-%02d", selectedMonth + 1, selectedDay);
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putString(getString(R.string.ski_season_start_key), selectedDate);
+            editor.apply();
         });
         builder.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss());
 
@@ -114,21 +129,24 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
 
     private void updateUnits() {
         UnitSystem unitSystem = PreferencesUtils.getUnitSystem();
-
         ListPreference statsRatePreferences = findPreference(getString(R.string.stats_rate_key));
 
-        int entriesId = switch (unitSystem) {
-            case METRIC -> R.array.stats_rate_metric_options;
-            case IMPERIAL_FEET, IMPERIAL_METER ->
-                    R.array.stats_rate_imperial_options;
-            case NAUTICAL_IMPERIAL ->
-                    R.array.stats_rate_nautical_options;
-        };
+        // Check for null to avoid NullPointerException
+        if (statsRatePreferences != null) {
+            int entriesId = switch (unitSystem) {
+                case METRIC -> R.array.stats_rate_metric_options;
+                case IMPERIAL_FEET, IMPERIAL_METER -> R.array.stats_rate_imperial_options;
+                case NAUTICAL_IMPERIAL -> R.array.stats_rate_nautical_options;
+            };
 
-        String[] entries = getResources().getStringArray(entriesId);
-        statsRatePreferences.setEntries(entries);
+            String[] entries = getResources().getStringArray(entriesId);
+            statsRatePreferences.setEntries(entries);
 
-        HackUtils.invalidatePreference(statsRatePreferences);
+            // Further actions could be added here if needed, e.g., updating other related
+            // preferences.
+        } else {
+            Log.w("DefaultsSettingsFragment", "Stats rate preference is not found.");
+        }
     }
 
     @Override

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -814,6 +814,9 @@ public class PreferencesUtils {
     public static List<String> getAllCustomLayoutNames() {
         return getAllCustomLayouts().stream().map(RecordingLayout::getName).collect(Collectors.toList());
     }
+    public static String getSkiSeasonStartDate() {
+        return getString(R.string.ski_season_start_key, "09-01");
+    }
 
     public static void resetCustomLayoutPreferences() {
         if (sharedPreferences.contains(resources.getString(R.string.stats_custom_layouts_key))) {
@@ -836,6 +839,10 @@ public class PreferencesUtils {
 
     public static void setShowOnMapFormat(final String showOnMapFormat) {
         setString(R.string.show_on_map_format_key, showOnMapFormat);
+    }
+
+    public static void setSkiSeasonStartDate(String newStartDate) {
+        setString(R.string.ski_season_start_key, newStartDate);
     }
 
     public static String getShowOnMapFormat() {

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -101,6 +101,14 @@ public class PreferencesUtils {
         setString(R.string.default_activity_key, newDefaultActivity);
     }
 
+    public static String getSkiSeasonStartDate() {
+        return getString(R.string.ski_season_start_key, "09-01");
+    }
+
+    public static void setSkiSeasonStartDate(String newStartDate) {
+        setString(R.string.ski_season_start_key, newStartDate);
+    }
+
     /**
      * Gets a preference key
      *

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -82,12 +82,14 @@ public class PreferencesUtils {
         PreferencesOpenHelper.newInstance(PREFERENCES_VERSION).check();
     }
 
-    public static void registerOnSharedPreferenceChangeListener(SharedPreferences.OnSharedPreferenceChangeListener changeListener) {
+    public static void registerOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener changeListener) {
         sharedPreferences.registerOnSharedPreferenceChangeListener(changeListener);
         changeListener.onSharedPreferenceChanged(sharedPreferences, null);
     }
 
-    public static void unregisterOnSharedPreferenceChangeListener(SharedPreferences.OnSharedPreferenceChangeListener changeListener) {
+    public static void unregisterOnSharedPreferenceChangeListener(
+            SharedPreferences.OnSharedPreferenceChangeListener changeListener) {
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(changeListener);
     }
 
@@ -301,7 +303,8 @@ public class PreferencesUtils {
     }
 
     public static boolean shouldShowStatsOnLockscreen() {
-        final boolean STATS_SHOW_ON_LOCKSCREEN_DEFAULT = resources.getBoolean(R.bool.stats_show_on_lockscreen_while_recording_default);
+        final boolean STATS_SHOW_ON_LOCKSCREEN_DEFAULT = resources
+                .getBoolean(R.bool.stats_show_on_lockscreen_while_recording_default);
         return getBoolean(R.string.stats_show_on_lockscreen_while_recording_key, STATS_SHOW_ON_LOCKSCREEN_DEFAULT);
     }
 
@@ -814,9 +817,6 @@ public class PreferencesUtils {
     public static List<String> getAllCustomLayoutNames() {
         return getAllCustomLayouts().stream().map(RecordingLayout::getName).collect(Collectors.toList());
     }
-    public static String getSkiSeasonStartDate() {
-        return getString(R.string.ski_season_start_key, "09-01");
-    }
 
     public static void resetCustomLayoutPreferences() {
         if (sharedPreferences.contains(resources.getString(R.string.stats_custom_layouts_key))) {
@@ -839,10 +839,6 @@ public class PreferencesUtils {
 
     public static void setShowOnMapFormat(final String showOnMapFormat) {
         setString(R.string.show_on_map_format_key, showOnMapFormat);
-    }
-
-    public static void setSkiSeasonStartDate(String newStartDate) {
-        setString(R.string.ski_season_start_key, newStartDate);
     }
 
     public static String getShowOnMapFormat() {

--- a/src/main/res/layout/custom_date_picker_dialog.xml
+++ b/src/main/res/layout/custom_date_picker_dialog.xml
@@ -1,0 +1,20 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:padding="1dp"
+    android:gravity="center">
+
+    <NumberPicker
+        android:id="@+id/monthPicker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:descendantFocusability="blocksDescendants"/>
+
+    <NumberPicker
+        android:id="@+id/dayPicker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:descendantFocusability="blocksDescendants"/>
+
+</LinearLayout>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -67,6 +67,8 @@
     <string name="default_activity_key" translatable="false">defaultActivity</string>
     <string name="default_activity_default" translatable="false">@string/activity_type_unknown</string>
 
+    <string name="ski_season_start_key" translatable="false">skiSeasonStartDate</string>
+
     <string name="recording_distance_interval_key" translatable="false">recordingDistanceInterval</string>
     <string name="recording_distance_interval_default" translatable="false">10</string>
     <string-array name="recording_distance_interval_values">

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -68,6 +68,8 @@
     <string name="default_activity_default" translatable="false">@string/activity_type_unknown</string>
 
     <string name="ski_season_start_key" translatable="false">skiSeasonStartDate</string>
+    <item name="monthPicker" type="id" />
+    <item name="dayPicker" type="id" />
 
     <string name="recording_distance_interval_key" translatable="false">recordingDistanceInterval</string>
     <string name="recording_distance_interval_default" translatable="false">10</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -366,6 +366,9 @@ limitations under the License.
     <string name="settings_units_category">Units</string>
     <string name="settings_activity_defaults_category">Activity\'s Defaults</string>
 
+    <string name="ski_season_start_title">Ski Season Start Date</string>
+    <string name="ski_season_start_summary">Specify the start date of the ski season.</string>
+
     <string name="settings_reset_summary">Reset Settings to Default Values</string>
 
     <!-- Settings Advanced -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -719,4 +719,5 @@ limitations under the License.
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="default_Date_Key">1 Sep</string>
 </resources>

--- a/src/main/res/xml/settings_defaults.xml
+++ b/src/main/res/xml/settings_defaults.xml
@@ -33,7 +33,7 @@
             android:key="@string/track_name_key"
             android:title="@string/settings_recording_track_name_title"
             app:useSimpleSummaryProvider="true" />
-         <Preference
+        <Preference
             android:key="@string/ski_season_start_key"
             android:defaultValue="@string/default_Date_Key"
             android:inputType="date"

--- a/src/main/res/xml/settings_defaults.xml
+++ b/src/main/res/xml/settings_defaults.xml
@@ -33,9 +33,13 @@
             android:key="@string/track_name_key"
             android:title="@string/settings_recording_track_name_title"
             app:useSimpleSummaryProvider="true" />
-        <Preference
+         <Preference
             android:key="@string/ski_season_start_key"
+            android:defaultValue="@string/default_Date_Key"
+            android:inputType="date"
             android:title="@string/ski_season_start_title"
-            android:summary="@string/ski_season_start_summary" />
+            android:summary="@string/default_Date_Key"
+            app:useSimpleSummaryProvider="true"
+            />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_defaults.xml
+++ b/src/main/res/xml/settings_defaults.xml
@@ -33,6 +33,9 @@
             android:key="@string/track_name_key"
             android:title="@string/settings_recording_track_name_title"
             app:useSimpleSummaryProvider="true" />
+        <Preference
+            android:key="@string/ski_season_start_key"
+            android:title="@string/ski_season_start_title"
+            android:summary="@string/ski_season_start_summary" />
     </PreferenceCategory>
-
 </PreferenceScreen>


### PR DESCRIPTION
Describe the pull request
Persist data locally on mobile device for default start date of Ski season

Link to the the issue
Closing  [rilling#85](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/85)