### PR TITLE
Settings: Add selection of default date and month for start of ski season

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -1,12 +1,17 @@
 package de.dennisguse.opentracks.settings;
-
+import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.NumberPicker;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import java.text.DateFormatSymbols;
+import java.util.Locale;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.models.ActivityType;
@@ -22,6 +27,14 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
             getActivity().runOnUiThread(this::updateUnits);
         }
     };
+    @Override
+    public boolean onPreferenceTreeClick(Preference preference) {
+        if (preference.getKey().equals(getString(R.string.ski_season_start_key))) {
+            showCustomDatePickerDialog(); // Call method to show the dialog
+            return true;
+        }
+        return super.onPreferenceTreeClick(preference);
+    }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -63,6 +76,37 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
 
         super.onDisplayPreferenceDialog(preference);
     }
+    private void showCustomDatePickerDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+        View dialogView = getLayoutInflater().inflate(R.layout.custom_date_picker_dialog, null);
+        builder.setView(dialogView);
+
+        NumberPicker monthPicker = dialogView.findViewById(R.id.monthPicker);
+        NumberPicker dayPicker = dialogView.findViewById(R.id.dayPicker);
+
+        // Customize month picker
+        String[] months = new DateFormatSymbols().getShortMonths();
+        monthPicker.setMinValue(0);
+        monthPicker.setMaxValue(months.length - 1);
+        monthPicker.setDisplayedValues(months);
+
+        // Customize day picker
+        dayPicker.setMinValue(1);
+        dayPicker.setMaxValue(31);
+
+        builder.setTitle("Select Date");
+        builder.setPositiveButton("OK", (dialog, which) -> {
+            int selectedMonth = monthPicker.getValue();
+            int selectedDay = dayPicker.getValue();
+
+            String selectedDate = String.format(Locale.getDefault(), "%02d-%02d", selectedDay, selectedMonth + 1);
+
+        });
+        builder.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss());
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
 
     private void updateUnits() {
         UnitSystem unitSystem = PreferencesUtils.getUnitSystem();
@@ -74,7 +118,7 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
             case IMPERIAL_FEET, IMPERIAL_METER ->
                     R.array.stats_rate_imperial_options;
             case NAUTICAL_IMPERIAL ->
-                R.array.stats_rate_nautical_options;
+                    R.array.stats_rate_nautical_options;
         };
 
         String[] entries = getResources().getStringArray(entriesId);

--- a/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/DefaultsSettingsFragment.java
@@ -94,6 +94,10 @@ public class DefaultsSettingsFragment extends PreferenceFragmentCompat implement
         dayPicker.setMinValue(1);
         dayPicker.setMaxValue(31);
 
+        //default date
+        monthPicker.setValue(8);
+        dayPicker.setValue(1);
+
         builder.setTitle("Select Date");
         builder.setPositiveButton("OK", (dialog, which) -> {
             int selectedMonth = monthPicker.getValue();

--- a/src/main/res/layout/custom_date_picker_dialog.xml
+++ b/src/main/res/layout/custom_date_picker_dialog.xml
@@ -1,0 +1,20 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:padding="1dp"
+    android:gravity="center">
+
+    <NumberPicker
+        android:id="@+id/monthPicker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:descendantFocusability="blocksDescendants"/>
+
+    <NumberPicker
+        android:id="@+id/dayPicker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:descendantFocusability="blocksDescendants"/>
+
+</LinearLayout>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -67,6 +67,8 @@
     <string name="default_activity_key" translatable="false">defaultActivity</string>
     <string name="default_activity_default" translatable="false">@string/activity_type_unknown</string>
 
+    <string name="ski_season_start_key" translatable="false">skiSeasonStartDate</string>
+
     <string name="recording_distance_interval_key" translatable="false">recordingDistanceInterval</string>
     <string name="recording_distance_interval_default" translatable="false">10</string>
     <string-array name="recording_distance_interval_values">

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -68,6 +68,8 @@
     <string name="default_activity_default" translatable="false">@string/activity_type_unknown</string>
 
     <string name="ski_season_start_key" translatable="false">skiSeasonStartDate</string>
+    <item name="monthPicker" type="id" />
+    <item name="dayPicker" type="id" />
 
     <string name="recording_distance_interval_key" translatable="false">recordingDistanceInterval</string>
     <string name="recording_distance_interval_default" translatable="false">10</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -366,6 +366,9 @@ limitations under the License.
     <string name="settings_units_category">Units</string>
     <string name="settings_activity_defaults_category">Activity\'s Defaults</string>
 
+    <string name="ski_season_start_title">Ski Season Start Date</string>
+    <string name="ski_season_start_summary">Specify the start date of the ski season.</string>
+
     <string name="settings_reset_summary">Reset Settings to Default Values</string>
 
     <!-- Settings Advanced -->

--- a/src/main/res/xml/settings_defaults.xml
+++ b/src/main/res/xml/settings_defaults.xml
@@ -33,6 +33,9 @@
             android:key="@string/track_name_key"
             android:title="@string/settings_recording_track_name_title"
             app:useSimpleSummaryProvider="true" />
+        <Preference
+            android:key="@string/ski_season_start_key"
+            android:title="@string/ski_season_start_title"
+            android:summary="@string/ski_season_start_summary" />
     </PreferenceCategory>
-
 </PreferenceScreen>


### PR DESCRIPTION
Describe the pull request
Settings: Add selection of default date and month for start of ski season 

Link to the the issue
Closing https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/101